### PR TITLE
Remove parent-width-dependent margin

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -330,7 +330,7 @@ pre > code {
 
 pre {
   margin: 10px;
-  width: 96%;
+  width: calc(100% - 20px); /* sum the left/right margins */
   padding: 0; /* useful for code elements */
 }
 

--- a/css/default.css
+++ b/css/default.css
@@ -329,7 +329,7 @@ pre > code {
 }
 
 pre {
-  margin: 10px 10px 10px 2%;
+  margin: 10px;
   width: 96%;
   padding: 0; /* useful for code elements */
 }


### PR DESCRIPTION
This width constraint is causing lots of small left-margin inconsistencies on table-based pages like this: https://beautyjoy.github.io/bjc-r/cur/programming/python/list_mutability.html?topic=berkeley_bjc%2Fpython%2Fbesides-blocks-data-struct.topic&course=cs10_fa16.html&novideo&noreading&noassignment

Screenshot:
<img width="408" alt="screen shot 2016-11-02 at 11 29 15 am" src="https://cloud.githubusercontent.com/assets/7411489/19942192/2b340d24-a0f0-11e6-8378-ccc8ae7911cf.png">
